### PR TITLE
feat(idm-credentials): format editor, fallback format, and progressive Next Step

### DIFF
--- a/src/components/pages/GoogleProvisioningWizard/GoogleProvisioningWizard.module.css
+++ b/src/components/pages/GoogleProvisioningWizard/GoogleProvisioningWizard.module.css
@@ -1196,3 +1196,12 @@
     line-height: 1.5;
     margin-top: 16px;
 }
+
+/* ── Credential Fallback Section ───────────── */
+
+.credentialFallbackSection {
+    border-top: 1px dashed var(--gray-300);
+    padding-top: 12px;
+    margin-top: 12px;
+    animation: section3SlideIn 300ms ease;
+}

--- a/src/components/pages/GoogleProvisioningWizard/steps/CredentialFormatEditorModal.jsx
+++ b/src/components/pages/GoogleProvisioningWizard/steps/CredentialFormatEditorModal.jsx
@@ -1,0 +1,385 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import { Modal } from "@/components/ui";
+import {
+    EMAIL_SIS_VARIABLES,
+    FORMAT_FUNCTIONS,
+} from "@/data/defaults/idm-provisioning";
+import styles from "../GoogleProvisioningWizard.module.css";
+
+/* ── Helpers ──────────────────────────────────── */
+
+/** Resolve a credential format segment array to a preview username string */
+export function resolveEmailPreview(rows, sampleUser, domain) {
+    if (!rows?.length) return "";
+    const username = rows
+        .map((seg) => {
+            if (seg.type === "text") return seg.value;
+            if (seg.type === "variable") {
+                const map = {
+                    "name.first": sampleUser.name?.split(" ")[0]?.toLowerCase() || "",
+                    "name.last": sampleUser.name?.split(" ").slice(1).join("").toLowerCase() || "",
+                    "student.sis_id": sampleUser.sisId || "",
+                    "student.student_number": sampleUser.studentNumber || "",
+                    "student.state_id": sampleUser.stateId || "",
+                    "student.district_username": sampleUser.districtUsername || "",
+                    "teacher.sis_id": sampleUser.sisId || "",
+                    "teacher.teacher_number": sampleUser.teacherNumber || "",
+                    "staff.sis_id": sampleUser.sisId || "",
+                    "staff.title": sampleUser.title?.toLowerCase() || "",
+                };
+                return map[seg.variable] ?? seg.variable;
+            }
+            if (seg.type === "function") return `[${seg.fn}]`;
+            return "";
+        })
+        .join("");
+    return domain ? `${username}@${domain}` : username;
+}
+
+/** Convert format segments back to emailTokens display array */
+export function formatToTokens(rows) {
+    return rows
+        .filter((seg) => seg.type === "variable")
+        .map((seg) => `{{${seg.variable}}}`);
+}
+
+/** Build an email template string from format segments + domain */
+export function formatToEmailString(rows, domain) {
+    const username = rows
+        .map((seg) => {
+            if (seg.type === "text") return seg.value;
+            if (seg.type === "variable") return `{{${seg.variable}}}`;
+            if (seg.type === "function") return `[${seg.fn}]`;
+            return "";
+        })
+        .join("");
+    return `${username}@${domain}`;
+}
+
+/* ── Format Row Component ─────────────────────── */
+
+function FormatRow({ row, index, total, onMoveUp, onMoveDown, onChange, onRemove, userType }) {
+    const typeBadgeClass =
+        row.type === "variable"
+            ? `${styles.formatRowType} ${styles.formatRowTypeVariable}`
+            : row.type === "function"
+            ? `${styles.formatRowType} ${styles.formatRowTypeFunction}`
+            : `${styles.formatRowType} ${styles.formatRowTypeText}`;
+
+    const typeLabel =
+        row.type === "variable" ? "Variable" : row.type === "function" ? "Function" : "Text";
+
+    return (
+        <div className={styles.formatRow}>
+            <div className={styles.formatRowArrows}>
+                <button
+                    className={styles.formatRowArrowBtn}
+                    disabled={index === 0}
+                    onClick={() => onMoveUp(index)}
+                    title="Move up"
+                >
+                    ▲
+                </button>
+                <button
+                    className={styles.formatRowArrowBtn}
+                    disabled={index === total - 1}
+                    onClick={() => onMoveDown(index)}
+                    title="Move down"
+                >
+                    ▼
+                </button>
+            </div>
+
+            <span className={typeBadgeClass}>{typeLabel}</span>
+
+            <div className={styles.formatRowValue}>
+                {row.type === "text" && (
+                    <input
+                        className={styles.formatRowInput}
+                        value={row.value}
+                        onChange={(e) => onChange(index, { ...row, value: e.target.value })}
+                    />
+                )}
+                {row.type === "variable" && (
+                    <select
+                        className={styles.formatRowSelect}
+                        value={row.variable}
+                        onChange={(e) => {
+                            const v = EMAIL_SIS_VARIABLES[userType]?.find(
+                                (sv) => sv.variable === e.target.value
+                            );
+                            onChange(index, {
+                                ...row,
+                                variable: e.target.value,
+                                label: v?.label || e.target.value,
+                            });
+                        }}
+                    >
+                        {(EMAIL_SIS_VARIABLES[userType] || []).map((v) => (
+                            <option key={v.variable} value={v.variable}>
+                                {v.label}
+                            </option>
+                        ))}
+                    </select>
+                )}
+                {row.type === "function" && (
+                    <span style={{ fontSize: 14, color: "var(--gray-700)" }}>{row.fn}</span>
+                )}
+            </div>
+
+            <button
+                className={styles.formatRowRemoveBtn}
+                onClick={() => onRemove(index)}
+                title="Remove"
+            >
+                &times;
+            </button>
+        </div>
+    );
+}
+
+/* ── Main Modal Component ─────────────────────── */
+
+export default function CredentialFormatEditorModal({
+    userType,
+    format,
+    domain,
+    sampleUser,
+    onSave,
+    onCancel,
+    title,
+}) {
+    const [rows, setRows] = useState(() => (format?.length ? [...format.map((r) => ({ ...r }))] : []));
+    const [functionsOpen, setFunctionsOpen] = useState(false);
+    const funcRef = useRef(null);
+
+    useEffect(() => {
+        if (!functionsOpen) return;
+        const handler = (e) => {
+            if (funcRef.current && !funcRef.current.contains(e.target)) {
+                setFunctionsOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", handler);
+        return () => document.removeEventListener("mousedown", handler);
+    }, [functionsOpen]);
+
+    /* ── Row operations ─────── */
+
+    const moveUp = (i) => {
+        if (i === 0) return;
+        setRows((prev) => {
+            const next = [...prev];
+            [next[i - 1], next[i]] = [next[i], next[i - 1]];
+            return next;
+        });
+    };
+
+    const moveDown = (i) => {
+        setRows((prev) => {
+            if (i >= prev.length - 1) return prev;
+            const next = [...prev];
+            [next[i], next[i + 1]] = [next[i + 1], next[i]];
+            return next;
+        });
+    };
+
+    const updateRow = (i, updated) => {
+        setRows((prev) => prev.map((r, idx) => (idx === i ? updated : r)));
+    };
+
+    const removeRow = (i) => {
+        setRows((prev) => prev.filter((_, idx) => idx !== i));
+    };
+
+    /* ── Add actions ─────── */
+
+    const addVariable = () => {
+        const vars = EMAIL_SIS_VARIABLES[userType] || [];
+        const first = vars[0];
+        setRows((prev) => [
+            ...prev,
+            { type: "variable", variable: first?.variable || "name.first", label: first?.label || "First Name" },
+        ]);
+    };
+
+    const addCustomText = () => {
+        setRows((prev) => [...prev, { type: "text", value: "" }]);
+    };
+
+    const addDot = () => {
+        setRows((prev) => [...prev, { type: "text", value: "." }]);
+    };
+
+    const addFunction = (fn) => {
+        setRows((prev) => [...prev, { type: "function", fn }]);
+        setFunctionsOpen(false);
+    };
+
+    const startOver = () => {
+        setRows([]);
+    };
+
+    /* ── Derived ─────── */
+
+    const userTypeLabel = userType === "students" ? "student" : userType === "teachers" ? "teacher" : "staff";
+    const previewEmail = resolveEmailPreview(rows, sampleUser, domain);
+
+    return (
+        <Modal
+            isOpen={true}
+            onClose={onCancel}
+            title={title || `Build email format for ${userTypeLabel}s`}
+            maxWidth="900px"
+        >
+            <div className={styles.formatEditorBody}>
+                {/* Left column: builder */}
+                <div className={styles.formatEditorLeft}>
+                    <p className={styles.formatEditorSubtitle}>
+                        Configure how {userTypeLabel} email usernames are constructed.
+                        The domain <strong>@{domain}</strong> will be appended automatically.
+                    </p>
+                    <p className={styles.formatEditorLinks}>
+                        <a href="#" className={styles.helpLink} onClick={(e) => e.preventDefault()}>
+                            Learn more about formats
+                        </a>
+                        {" | "}
+                        <a
+                            href="#"
+                            className={styles.helpLink}
+                            onClick={(e) => {
+                                e.preventDefault();
+                                startOver();
+                            }}
+                        >
+                            Start over
+                        </a>
+                    </p>
+
+                    {/* Rows */}
+                    {rows.map((row, i) => (
+                        <FormatRow
+                            key={i}
+                            row={row}
+                            index={i}
+                            total={rows.length}
+                            onMoveUp={moveUp}
+                            onMoveDown={moveDown}
+                            onChange={updateRow}
+                            onRemove={removeRow}
+                            userType={userType}
+                        />
+                    ))}
+
+                    {rows.length === 0 && (
+                        <div
+                            style={{
+                                padding: 24,
+                                textAlign: "center",
+                                color: "var(--gray-500)",
+                                fontSize: 14,
+                                border: "2px dashed var(--gray-200)",
+                                borderRadius: 8,
+                                marginBottom: 8,
+                            }}
+                        >
+                            No format segments yet. Use the buttons below to build your email format.
+                        </div>
+                    )}
+
+                    {/* Add buttons */}
+                    <div className={styles.addButtonsRow}>
+                        <button className={styles.addBtn} onClick={addDot}>
+                            + Add &quot;.&quot;
+                        </button>
+                        <button className={styles.addBtn} onClick={addVariable}>
+                            + Add an SIS Variable
+                        </button>
+                        <button className={styles.addBtn} onClick={addCustomText}>
+                            + Add Custom Text
+                        </button>
+                        <div className={styles.addBtnWrapper} ref={funcRef}>
+                            <button
+                                className={styles.addBtn}
+                                onClick={() => setFunctionsOpen((v) => !v)}
+                            >
+                                + Add a Function ▼
+                            </button>
+                            {functionsOpen && (
+                                <div className={styles.functionsMenu}>
+                                    {FORMAT_FUNCTIONS.map((fn) => (
+                                        <button
+                                            key={fn}
+                                            className={styles.functionsMenuItem}
+                                            onClick={() => addFunction(fn)}
+                                        >
+                                            {fn}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Footer */}
+                    <div className={styles.modalFooter}>
+                        <button className={styles.nextBtn} onClick={() => onSave(rows)}>
+                            Save format
+                        </button>
+                        <button className={styles.cancelBtn} onClick={onCancel}>
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+
+                {/* Right column: preview */}
+                <div className={styles.formatEditorRight}>
+                    <div className={styles.modalPreviewPanel}>
+                        <div className={styles.modalPreviewSection}>
+                            <div style={{ fontSize: 13, fontWeight: 600, color: "var(--gray-600)", marginBottom: 8 }}>
+                                PREVIEW
+                            </div>
+                            <div style={{ marginBottom: 8 }}>
+                                <div style={{ fontSize: 12, fontWeight: 600, color: "var(--gray-500)", marginBottom: 2 }}>
+                                    USER NAME
+                                </div>
+                                <select
+                                    style={{
+                                        width: "100%",
+                                        padding: "6px 8px",
+                                        border: "1px solid var(--gray-300)",
+                                        borderRadius: 4,
+                                        fontSize: 13,
+                                        background: "white",
+                                    }}
+                                    defaultValue={sampleUser.name}
+                                >
+                                    <option>{sampleUser.name}</option>
+                                </select>
+                            </div>
+
+                            {rows.length > 0 && (
+                                <div className={styles.modalPreviewResult}>
+                                    <div style={{ fontSize: 13, fontWeight: 600, color: "var(--gray-900)" }}>
+                                        Example email
+                                    </div>
+                                    <div style={{ fontSize: 14, color: "var(--gray-800)", marginTop: 4, wordBreak: "break-all" }}>
+                                        {previewEmail}
+                                    </div>
+                                </div>
+                            )}
+
+                            {rows.length === 0 && (
+                                <div style={{ fontSize: 13, color: "var(--gray-500)", fontStyle: "italic" }}>
+                                    Add format segments to see a preview.
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Modal>
+    );
+}

--- a/src/components/pages/GoogleProvisioningWizard/steps/SetCredentialsStep.jsx
+++ b/src/components/pages/GoogleProvisioningWizard/steps/SetCredentialsStep.jsx
@@ -1,7 +1,15 @@
 "use client";
 
 import React, { useState } from "react";
-import { SAMPLE_STUDENT, SAMPLE_TEACHER, SAMPLE_STAFF } from "@/data/defaults/idm-provisioning";
+import {
+    SAMPLE_STUDENT, SAMPLE_TEACHER, SAMPLE_STAFF,
+    EMAIL_SIS_VARIABLES,
+} from "@/data/defaults/idm-provisioning";
+import CredentialFormatEditorModal, {
+    resolveEmailPreview,
+    formatToTokens,
+    formatToEmailString,
+} from "./CredentialFormatEditorModal";
 import styles from "../GoogleProvisioningWizard.module.css";
 
 const CheckIcon = () => (
@@ -9,6 +17,24 @@ const CheckIcon = () => (
         <path d="M3 6l2.5 2.5L9 4" stroke="white" strokeWidth="2" strokeLinecap="round" />
     </svg>
 );
+
+/** Migrate old credential state that lacks emailFormat/fallback fields */
+function migrateCredential(cred) {
+    if (cred.emailFormat) return cred;
+    // Derive emailFormat from emailTokens
+    const emailFormat = (cred.emailTokens || []).map((token) => {
+        const variable = token.replace(/\{\{|\}\}/g, "");
+        const vars = Object.values(EMAIL_SIS_VARIABLES).flat();
+        const match = vars.find((v) => v.variable === variable);
+        return { type: "variable", variable, label: match?.label || variable };
+    });
+    return {
+        ...cred,
+        emailFormat,
+        fallbackEnabled: false,
+        fallbackFormat: [],
+    };
+}
 
 function CredentialCard({ title, credential, onEdit }) {
     return (
@@ -38,6 +64,114 @@ function CredentialCard({ title, credential, onEdit }) {
 
 function CredentialEditView({ title, userType, credential, sample, onBack, updateState, state }) {
     const [domain] = useState(credential.domain);
+    const [showFormatEditor, setShowFormatEditor] = useState(false);
+    const [showFallbackEditor, setShowFallbackEditor] = useState(false);
+    const [section, setSection] = useState(1); // 1 = user preview, 2 = email config
+
+    const cred = migrateCredential(credential);
+
+    // Compute preview email from format segments
+    const previewEmail = cred.emailFormat?.length
+        ? resolveEmailPreview(cred.emailFormat, sample, domain)
+        : sample.exampleEmail;
+
+    const fallbackPreviewEmail = cred.fallbackEnabled && cred.fallbackFormat?.length
+        ? resolveEmailPreview(cred.fallbackFormat, sample, domain)
+        : null;
+
+    /** Save primary format from modal */
+    const handleFormatSave = (rows) => {
+        const emailTokens = formatToTokens(rows);
+        const email = formatToEmailString(rows, domain);
+        updateState({
+            credentials: {
+                ...state.credentials,
+                [userType]: {
+                    ...state.credentials[userType],
+                    emailFormat: rows,
+                    emailTokens,
+                    email,
+                },
+            },
+        });
+        setShowFormatEditor(false);
+    };
+
+    /** Save fallback format from modal */
+    const handleFallbackSave = (rows) => {
+        updateState({
+            credentials: {
+                ...state.credentials,
+                [userType]: {
+                    ...state.credentials[userType],
+                    fallbackFormat: rows,
+                    fallbackEnabled: true,
+                },
+            },
+        });
+        setShowFallbackEditor(false);
+    };
+
+    /** Enable fallback and show editor */
+    const handleAddFallback = (e) => {
+        e.preventDefault();
+        if (!cred.fallbackEnabled) {
+            // Enable with default format
+            const defaultFallback = [
+                { type: "variable", variable: "name.first", label: "First Name" },
+                { type: "text", value: "." },
+                { type: "variable", variable: "name.last", label: "Last Name" },
+            ];
+            updateState({
+                credentials: {
+                    ...state.credentials,
+                    [userType]: {
+                        ...state.credentials[userType],
+                        fallbackEnabled: true,
+                        fallbackFormat: defaultFallback,
+                    },
+                },
+            });
+        } else {
+            setShowFallbackEditor(true);
+        }
+    };
+
+    /** Remove fallback */
+    const handleRemoveFallback = (e) => {
+        e.preventDefault();
+        updateState({
+            credentials: {
+                ...state.credentials,
+                [userType]: {
+                    ...state.credentials[userType],
+                    fallbackEnabled: false,
+                    fallbackFormat: [],
+                },
+            },
+        });
+    };
+
+    /** Next Step: progressive disclosure, then save */
+    const handleNextStep = () => {
+        if (section === 1) {
+            setSection(2);
+        } else {
+            // Section 2 → save + return to overview
+            updateState({
+                credentials: {
+                    ...state.credentials,
+                    [userType]: {
+                        ...state.credentials[userType],
+                        completed: true,
+                    },
+                },
+            });
+            onBack();
+        }
+    };
+
+    const nextButtonLabel = section === 1 ? "Next Step" : "Save";
 
     return (
         <>
@@ -85,91 +219,153 @@ function CredentialEditView({ title, userType, credential, sample, onBack, updat
                 </div>
             </div>
 
-            {/* Section 2: Email credentials */}
-            <div className={styles.card}>
-                <h3 style={{ fontSize: 15, fontWeight: 600, margin: "0 0 12px 0" }}>
-                    2. Select email credentials
-                </h3>
+            {/* Section 2: Email credentials — revealed on Next Step */}
+            {section >= 2 && (
+                <div className={`${styles.card} ${styles.section3Container}`}>
+                    <h3 style={{ fontSize: 15, fontWeight: 600, margin: "0 0 12px 0" }}>
+                        2. Select email credentials
+                    </h3>
 
-                <div style={{ marginBottom: 16 }}>
-                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
-                        <h4 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>Matching emails</h4>
-                        <span className={styles.recommendBadge}>Match credentials</span>
-                    </div>
-                    <p style={{ fontSize: 14, color: "var(--gray-600)", lineHeight: 1.5, margin: "0 0 12px 0" }}>
-                        Clever IDM uses the SIS email associated with the user in Clever to automatically
-                        link to matching accounts in Google. Only those users whose SIS email matches the
-                        domain will be matched.
-                    </p>
-                    <div style={{ marginBottom: 8 }}>
-                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                            <span style={{ fontSize: 13, color: "var(--gray-600)" }}>
-                                Select the associated email domain for {userType}
-                            </span>
-                            <span style={{ fontSize: 13, color: "var(--gray-600)", fontStyle: "italic" }}>Required</span>
+                    <div style={{ marginBottom: 16 }}>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+                            <h4 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>Matching emails</h4>
+                            <span className={styles.recommendBadge}>Match credentials</span>
                         </div>
-                        <select
-                            style={{
-                                width: "100%", maxWidth: 400, padding: "8px 12px",
-                                border: "1px solid var(--gray-300)", borderRadius: 6,
-                                fontSize: 14, color: "var(--gray-900)", background: "white", marginTop: 4,
-                            }}
-                            defaultValue={domain}
+                        <p style={{ fontSize: 14, color: "var(--gray-600)", lineHeight: 1.5, margin: "0 0 12px 0" }}>
+                            Clever IDM uses the SIS email associated with the user in Clever to automatically
+                            link to matching accounts in Google. Only those users whose SIS email matches the
+                            domain will be matched.
+                        </p>
+                        <div style={{ marginBottom: 8 }}>
+                            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                                <span style={{ fontSize: 13, color: "var(--gray-600)" }}>
+                                    Select the associated email domain for {userType}
+                                </span>
+                                <span style={{ fontSize: 13, color: "var(--gray-600)", fontStyle: "italic" }}>Required</span>
+                            </div>
+                            <select
+                                style={{
+                                    width: "100%", maxWidth: 400, padding: "8px 12px",
+                                    border: "1px solid var(--gray-300)", borderRadius: 6,
+                                    fontSize: 14, color: "var(--gray-900)", background: "white", marginTop: 4,
+                                }}
+                                defaultValue={domain}
+                            >
+                                <option>{domain}</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div style={{ borderTop: "1px solid var(--gray-200)", paddingTop: 16 }}>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+                            <h4 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>
+                                Create an email format for all unmatched users
+                            </h4>
+                            <span className={styles.limitedBadge}>Create credentials</span>
+                        </div>
+                        <p style={{ fontSize: 14, color: "var(--gray-600)", lineHeight: 1.5, margin: "0 0 12px 0" }}>
+                            To create an email format for {userType}, combine a username and a domain.
+                            Clever IDM will only use this format if the user&apos;s email address isn&apos;t
+                            populated in Clever already.
+                        </p>
+
+                        {/* Primary format display */}
+                        <div className={styles.formatTagRow}>
+                            {(cred.emailFormat || []).map((seg, i) => (
+                                seg.type === "variable" ? (
+                                    <span key={i} className={styles.formatTag}>
+                                        {`{{${seg.variable}}}`}
+                                    </span>
+                                ) : (
+                                    <span key={i} className={styles.formatTagText}>
+                                        {seg.value}
+                                    </span>
+                                )
+                            ))}
+                            {(!cred.emailFormat || cred.emailFormat.length === 0) && (
+                                <span style={{ fontSize: 13, color: "var(--gray-500)", fontStyle: "italic" }}>
+                                    No format configured
+                                </span>
+                            )}
+                        </div>
+                        <button
+                            className={styles.editFormatLink}
+                            onClick={() => setShowFormatEditor(true)}
                         >
-                            <option>{domain}</option>
-                        </select>
+                            Edit your format
+                        </button>
+
+                        {/* Email preview */}
+                        <div className={styles.card} style={{ background: "var(--gray-50)", marginTop: 12 }}>
+                            <div style={{ fontSize: 14, color: "var(--gray-700)" }}>
+                                👁 {sample.name}&apos;s email format
+                            </div>
+                            <div style={{ fontSize: 14, marginTop: 4 }}>
+                                <strong>Example email</strong> {previewEmail}
+                            </div>
+                        </div>
+
+                        {/* Fallback section */}
+                        {cred.fallbackEnabled ? (
+                            <div className={styles.credentialFallbackSection}>
+                                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8, marginTop: 16 }}>
+                                    <h4 style={{ fontSize: 14, fontWeight: 600, margin: 0, color: "var(--gray-800)" }}>
+                                        Fallback create format
+                                    </h4>
+                                    <a href="#" className={styles.helpLink} onClick={handleRemoveFallback}
+                                        style={{ fontSize: 13 }}>
+                                        Remove fallback
+                                    </a>
+                                </div>
+                                <p style={{ fontSize: 13, color: "var(--gray-600)", lineHeight: 1.5, margin: "0 0 8px 0" }}>
+                                    If the primary email format produces a conflict, this fallback format will be used instead.
+                                </p>
+                                <div className={styles.formatTagRow}>
+                                    {(cred.fallbackFormat || []).map((seg, i) => (
+                                        seg.type === "variable" ? (
+                                            <span key={i} className={styles.formatTag}>
+                                                {`{{${seg.variable}}}`}
+                                            </span>
+                                        ) : (
+                                            <span key={i} className={styles.formatTagText}>
+                                                {seg.value}
+                                            </span>
+                                        )
+                                    ))}
+                                </div>
+                                <button
+                                    className={styles.editFormatLink}
+                                    onClick={() => setShowFallbackEditor(true)}
+                                >
+                                    Edit fallback format
+                                </button>
+                                {fallbackPreviewEmail && (
+                                    <div className={styles.card} style={{ background: "var(--gray-50)", marginTop: 12 }}>
+                                        <div style={{ fontSize: 14, color: "var(--gray-700)" }}>
+                                            👁 {sample.name}&apos;s fallback email
+                                        </div>
+                                        <div style={{ fontSize: 14, marginTop: 4 }}>
+                                            <strong>Example email</strong> {fallbackPreviewEmail}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        ) : (
+                            <button
+                                className={styles.editFormatLink}
+                                onClick={handleAddFallback}
+                                style={{ display: "block", marginTop: 8 }}
+                            >
+                                Add fallback create format ℹ️
+                            </button>
+                        )}
                     </div>
                 </div>
-
-                <div style={{ borderTop: "1px solid var(--gray-200)", paddingTop: 16 }}>
-                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
-                        <h4 style={{ fontSize: 15, fontWeight: 600, margin: 0 }}>
-                            Create an email format for all unmatched users
-                        </h4>
-                        <span className={styles.limitedBadge}>Create credentials</span>
-                    </div>
-                    <p style={{ fontSize: 14, color: "var(--gray-600)", lineHeight: 1.5, margin: "0 0 12px 0" }}>
-                        To create an email format for {userType}, combine a username and a domain.
-                        Clever IDM will only use this format if the user&apos;s email address isn&apos;t
-                        populated in Clever already.
-                    </p>
-                    <div style={{
-                        background: "var(--gray-50)", border: "1px solid var(--gray-200)",
-                        borderRadius: 6, padding: "10px 16px", display: "flex", gap: 8, flexWrap: "wrap",
-                        marginBottom: 8,
-                    }}>
-                        {credential.emailTokens.map((token, i) => (
-                            <span key={i} style={{
-                                background: "#c084fc", color: "white", padding: "4px 10px",
-                                borderRadius: 14, fontSize: 13, fontWeight: 500,
-                            }}>
-                                {token}
-                            </span>
-                        ))}
-                    </div>
-                    <a href="#" className={styles.helpLink} onClick={(e) => e.preventDefault()}
-                        style={{ fontSize: 14 }}>
-                        Edit your format
-                    </a>
-
-                    <div className={styles.card} style={{ background: "var(--gray-50)", marginTop: 12 }}>
-                        <div style={{ fontSize: 14, color: "var(--gray-700)" }}>
-                            👁 {sample.name}&apos;s email format
-                        </div>
-                        <div style={{ fontSize: 14, marginTop: 4 }}>
-                            <strong>Example email</strong> {sample.exampleEmail}
-                        </div>
-                    </div>
-                    <a href="#" className={styles.helpLink} onClick={(e) => e.preventDefault()}
-                        style={{ fontSize: 14 }}>
-                        Add fallback create format ℹ️
-                    </a>
-                </div>
-            </div>
+            )}
 
             <div className={styles.nextBtnRow}>
-                <button className={styles.nextBtn} onClick={onBack}>
-                    Next Step
+                <button className={styles.nextBtn} onClick={handleNextStep}>
+                    {nextButtonLabel}
                 </button>
             </div>
 
@@ -183,6 +379,30 @@ function CredentialEditView({ title, userType, credential, sample, onBack, updat
                     of our Clever IDM course in Clever Academy!
                 </span>
             </div>
+
+            {/* Format Editor Modals */}
+            {showFormatEditor && (
+                <CredentialFormatEditorModal
+                    userType={userType}
+                    format={cred.emailFormat}
+                    domain={domain}
+                    sampleUser={sample}
+                    onSave={handleFormatSave}
+                    onCancel={() => setShowFormatEditor(false)}
+                    title="Edit email format"
+                />
+            )}
+            {showFallbackEditor && (
+                <CredentialFormatEditorModal
+                    userType={userType}
+                    format={cred.fallbackFormat}
+                    domain={domain}
+                    sampleUser={sample}
+                    onSave={handleFallbackSave}
+                    onCancel={() => setShowFallbackEditor(false)}
+                    title="Edit fallback email format"
+                />
+            )}
         </>
     );
 }

--- a/src/data/defaults/idm-provisioning.js
+++ b/src/data/defaults/idm-provisioning.js
@@ -39,6 +39,12 @@ export const DEFAULT_PROVISIONING_STATE = {
             password: "{{student.student_number}}{{student.grade}}{{school.sis_id}}",
             domain: "maytonlyceum.com",
             emailTokens: ["{{name.first}}", "{{name.last}}"],
+            emailFormat: [
+                { type: "variable", variable: "name.first", label: "First Name" },
+                { type: "variable", variable: "name.last", label: "Last Name" },
+            ],
+            fallbackEnabled: false,
+            fallbackFormat: [],
         },
         teachers: {
             completed: true,
@@ -46,6 +52,12 @@ export const DEFAULT_PROVISIONING_STATE = {
             password: "{{teacher.teacher_number}}0420",
             domain: "maytonlyceum.com",
             emailTokens: ["{{name.first}}", "{{name.last}}"],
+            emailFormat: [
+                { type: "variable", variable: "name.first", label: "First Name" },
+                { type: "variable", variable: "name.last", label: "Last Name" },
+            ],
+            fallbackEnabled: false,
+            fallbackFormat: [],
         },
         staff: {
             completed: true,
@@ -53,6 +65,12 @@ export const DEFAULT_PROVISIONING_STATE = {
             password: "{{staff.title}}{{school.sis_id}}",
             domain: "maytonlyceum.com",
             emailTokens: ["{{name.first}}", "{{name.last}}"],
+            emailFormat: [
+                { type: "variable", variable: "name.first", label: "First Name" },
+                { type: "variable", variable: "name.last", label: "Last Name" },
+            ],
+            fallbackEnabled: false,
+            fallbackFormat: [],
         },
     },
 
@@ -220,6 +238,30 @@ export const SIS_VARIABLES = {
         { variable: "school_name", label: "School Name" },
         { variable: "staff.title", label: "Title" },
         { variable: "staff.department", label: "Department" },
+    ],
+};
+
+/** Email-specific SIS variables — includes name fields for credential format building */
+export const EMAIL_SIS_VARIABLES = {
+    students: [
+        { variable: "name.first", label: "First Name" },
+        { variable: "name.last", label: "Last Name" },
+        { variable: "student.sis_id", label: "SIS ID" },
+        { variable: "student.student_number", label: "Student Number" },
+        { variable: "student.state_id", label: "State ID" },
+        { variable: "student.district_username", label: "District Username" },
+    ],
+    teachers: [
+        { variable: "name.first", label: "First Name" },
+        { variable: "name.last", label: "Last Name" },
+        { variable: "teacher.sis_id", label: "SIS ID" },
+        { variable: "teacher.teacher_number", label: "Teacher Number" },
+    ],
+    staff: [
+        { variable: "name.first", label: "First Name" },
+        { variable: "name.last", label: "Last Name" },
+        { variable: "staff.sis_id", label: "SIS ID" },
+        { variable: "staff.title", label: "Title" },
     ],
 };
 

--- a/tests/e2e/route-persistence.spec.js
+++ b/tests/e2e/route-persistence.spec.js
@@ -136,6 +136,93 @@ test("Section 3 expansion: Teacher OUs shows Build your format", async ({ page }
     await expect(page.getByRole("heading", { name: "Organize OUs" })).toBeVisible();
 });
 
+/* ── Credential Format Edit Flow ────────────────── */
+
+test("credential format edit: Edit your format opens modal and saves", async ({ page }) => {
+    await page.goto("/dashboard/idm/provisioning/credentials");
+    await expect(page.getByText("Set login credentials").first()).toBeVisible();
+
+    // Click Edit on Student credentials card
+    const editBtn = page.getByRole("button", { name: "Edit" }).first();
+    await editBtn.click();
+
+    // Should show Student edit view
+    await expect(page.getByRole("heading", { name: /Student login credentials/ })).toBeVisible();
+
+    // Click "Next Step" to reveal Section 2
+    await page.getByRole("button", { name: "Next Step" }).click();
+
+    // Section 2 should be visible with email config
+    await expect(page.getByText("Select email credentials")).toBeVisible();
+
+    // Click "Edit your format" — should open modal
+    await page.getByRole("button", { name: "Edit your format" }).click();
+    await expect(page.getByText("Edit email format")).toBeVisible();
+
+    // Modal should show format builder with save button
+    await expect(page.getByRole("button", { name: "Save format" })).toBeVisible();
+
+    // Click "Save format" to close modal
+    await page.getByRole("button", { name: "Save format" }).click();
+
+    // Modal should be closed, back to credential edit view
+    await expect(page.getByText("Select email credentials")).toBeVisible();
+
+    // Click "Save" to return to overview
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("Set login credentials").first()).toBeVisible();
+});
+
+test("credential format edit: Add fallback creates fallback section", async ({ page }) => {
+    await page.goto("/dashboard/idm/provisioning/credentials");
+
+    // Edit student credentials
+    const editBtn = page.getByRole("button", { name: "Edit" }).first();
+    await editBtn.click();
+
+    // Reveal Section 2
+    await page.getByRole("button", { name: "Next Step" }).click();
+    await expect(page.getByText("Select email credentials")).toBeVisible();
+
+    // Click "Add fallback create format"
+    await page.getByRole("button", { name: /Add fallback/ }).click();
+
+    // Fallback section should appear with edit link and preview
+    await expect(page.getByText("Fallback create format")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Edit fallback format" })).toBeVisible();
+
+    // Fallback preview should be visible
+    await expect(page.getByText(/fallback email/)).toBeVisible();
+
+    // Save returns to overview
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("Set login credentials").first()).toBeVisible();
+});
+
+test("credential format persists through reload", async ({ page }) => {
+    await page.goto("/dashboard/idm/provisioning/credentials");
+
+    // Edit student credentials
+    const editBtn = page.getByRole("button", { name: "Edit" }).first();
+    await editBtn.click();
+
+    // Reveal Section 2 and add fallback
+    await page.getByRole("button", { name: "Next Step" }).click();
+    await page.getByRole("button", { name: /Add fallback/ }).click();
+    await expect(page.getByText("Fallback create format")).toBeVisible();
+
+    // Save
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("Set login credentials").first()).toBeVisible();
+
+    // Reload
+    await page.reload();
+
+    // Verify we're still on credentials page
+    await expect(page).toHaveURL(/\/dashboard\/idm\/provisioning\/credentials$/);
+    await expect(page.getByText("Set login credentials").first()).toBeVisible();
+});
+
 test("Ignored OUs Next step reveals handling sections and Save returns to overview", async ({ page }) => {
     await page.goto("/dashboard/idm/provisioning/ous");
     await expect(page.getByRole("heading", { name: "Organize OUs" })).toBeVisible();


### PR DESCRIPTION
## Summary
- **Edit your format**: Opens `CredentialFormatEditorModal` — a segment-based email username builder (variables, text, functions) with live preview, adapted from the OU FormatEditorModal pattern
- **Add fallback create format**: Reveals an editable fallback format section with its own preview; can be removed after creation
- **Next Step progressive disclosure**: Section 1 (user preview) → Section 2 (email config) → Save returns to overview with `completed: true`
- **Data model**: Adds `emailFormat`, `fallbackEnabled`, `fallbackFormat` to credential state; adds `EMAIL_SIS_VARIABLES` with name/ID fields; migration-safe for existing localStorage

## Files changed (6)
| File | Purpose |
|------|---------|
| `src/data/defaults/idm-provisioning.js` | Extended credential defaults + `EMAIL_SIS_VARIABLES` |
| `src/components/.../CredentialFormatEditorModal.jsx` | New modal: email format segment builder with preview |
| `src/components/.../SetCredentialsStep.jsx` | Rewired all three controls; progressive disclosure flow |
| `src/components/.../GoogleProvisioningWizard.module.css` | `.credentialFallbackSection` style |
| `src/__tests__/idm-provisioning-wizard.test.js` | +17 tests: format defaults, fallback defaults, state mutations, EMAIL_SIS_VARIABLES |
| `tests/e2e/route-persistence.spec.js` | +3 E2E tests: format edit flow, fallback creation, persistence |

## Test plan
- [x] `npm run lint` — passes
- [x] `npm test` — 87/87 tests pass (was 70)
- [x] `npm run build` — compiles successfully
- [ ] Manual: Navigate to credentials step, edit student, verify progressive Section 1→2 flow
- [ ] Manual: Click "Edit your format" → modal opens → save → preview updates
- [ ] Manual: Click "Add fallback" → fallback section appears → editable → preview shows
- [ ] Manual: Save → reload → state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)