### PR TITLE
Phase 8: Credential Building Implementation

### DIFF
--- a/docs/phase-8-plan.md
+++ b/docs/phase-8-plan.md
@@ -1,0 +1,95 @@
+# Phase 8: Module 3 Completion — `scenario_credential_building`
+
+## Context
+
+Module 3 (Credential Configuration) has 1 of 2 scenarios authored. The existing `scenario_idm_credentials` covers *navigation* to the credential step and *reading* the current format. The missing `scenario_credential_building` (already listed in `curriculum.js`) should cover *deeper conceptual understanding* of the credential system — SIS variables, password formats, fallback concepts, and matching vs. creating.
+
+Once this scenario is added, Module 3 will have 2/2 scenarios, completing it and activating the prerequisite chain for Module 4.
+
+**Goal:** Author `scenario_credential_building` and update TicketInbox tests.
+
+## Branch
+Fresh branch from current main: `git checkout main && git pull && git checkout -b codex/phase-8-credential-building`
+
+## Protected files (DO NOT MODIFY)
+CoachMark.jsx, Sidebar.jsx, DataTable.jsx, tests/e2e/*, auth/security files
+
+---
+
+## Step 1: Author `scenario_credential_building` (11 main steps + 4 wrong-answer branches)
+
+**File:** `src/data/scenarios.js` — insert immediately after `scenario_idm_credentials` (line 813).
+
+**Metadata:**
+```js
+id: "scenario_credential_building",
+customerId: "sarahChen",
+moduleId: "mod_credentials",
+ticketSubject: "Need to understand credential formats before making changes",
+ticketPriority: "normal",
+ticketNumber: 1006,
+```
+
+**Character:** Sarah Chen — IT Coordinator at Treutelside Middle School. First scenario use. Technically minded, asking deep questions before making changes.
+
+**Design:** Conceptual/knowledge scenario (no task steps, no navigation). All answers derive from `DEFAULT_PROVISIONING_STATE`, `EMAIL_SIS_VARIABLES`, and sample user data.
+
+**Steps:**
+
+| # | ID | Type | Question | Answer / Validation |
+|---|-----|------|---------|---------------------|
+| 1 | `step_cb_intro` | message | "Before I make changes, I want to understand the format system." | Single action → step 2 |
+| 2 | `step_cb_user_types` | input | "How many user types have credential configurations?" | `["3", "three"]`, oneOf. (students/teachers/staff all provisioned) |
+| 3 | `step_cb_shared_domain` | input | "Do they share a domain? What is it?" | `matchMode: "includes"`, `correctAnswer: "maytonlyceum.com"`. Accepts any response containing the domain. |
+| 4 | `step_cb_sis_variables` | message | "Are SIS variables the same for all types?" | Correct: "They're different per type" / Wrong → 4a |
+| 4a | `step_cb_sis_variables_wrong` | message | "Students have Student Number but teachers don't…" | Correction → step 5 |
+| 5 | `step_cb_student_variable` | input | "Besides First/Last Name, how many student email variables?" | `"4"`, exact. (sis_id, student_number, state_id, district_username) |
+| 6 | `step_cb_password_format` | message | "What does the student password format combine?" | Correct: "student number + grade + school SIS ID" / Wrong → 6a |
+| 6a | `step_cb_password_format_wrong` | message | "I saw student_number and grade variables…" | Correction → step 7 |
+| 7 | `step_cb_teacher_password` | input | "Betty Bauch, teacher number T001 — what's her password?" | `"t0010420"`, exact. (format: `{{teacher.teacher_number}}0420`, checkAnswer lowercases both sides) |
+| 8 | `step_cb_fallback` | message | "What's a fallback email format?" | Correct: "Used when primary produces a conflict" / Wrong → 8a |
+| 8a | `step_cb_fallback_wrong` | message | "Password reset is different. Fallback is about conflicts?" | Correction → step 9 |
+| 9 | `step_cb_matching` | message | "What's the difference between matching and creating?" | Correct: "Matching links existing Google accts via SIS email; creating builds new ones" / Wrong → 9a |
+| 9a | `step_cb_matching_wrong` | message | "SIS email matching sounds different from creating new ones?" | Correction → step 10 |
+| 10 | `step_cb_staff_email` | input | "Oswaldo Pouros — what would his email be?" | `["oswaldopouros@maytonlyceum.com", "oswaldo.pouros@maytonlyceum.com"]`, oneOf. Accepts both concatenated and dotted formats. |
+| 11 | `step_cb_done` | message | "Three types, shared domain, different SIS variables… I'm confident now!" | Two closing actions → null |
+
+**Answer sources:**
+- Step 2: `provisionStudents/Teachers/Staff` all `true` in DEFAULT_PROVISIONING_STATE. oneOf `["3", "three"]` for natural phrasing.
+- Step 3: All 3 credential configs use `domain: "maytonlyceum.com"`. `includes` match so "maytonlyceum.com", "it's maytonlyceum.com", etc. all pass.
+- Step 5: `EMAIL_SIS_VARIABLES.students` has 6 entries minus 2 name fields = 4
+- Step 7: `credentials.teachers.password` = `"{{teacher.teacher_number}}0420"`, `SAMPLE_TEACHER.teacherNumber` = `"T001"`
+- Step 10: `SAMPLE_STAFF.name` = `"Oswaldo Pouros"`, format = `{{name.first}}{{name.last}}@maytonlyceum.com`. oneOf accepts both `oswaldopouros@` and `oswaldo.pouros@` to avoid false negatives.
+
+---
+
+## Step 2: Update TicketInbox Tests
+
+**File:** `src/__tests__/TicketInbox.test.jsx`
+
+**What changes:** Module 3 now has 2 authored scenarios, so the inbox will render a second Module 3 ticket. Tests should verify:
+
+1. **Add** a test that Module 3 renders both ticket subjects:
+   ```js
+   it("renders Module 3 scenarios", () => {
+       renderInbox({
+           completedModules: new Set(["mod_overview", "mod_provisioning_basics"]),
+       });
+       expect(screen.getByText("Change student email format to first initial + last name")).toBeInTheDocument();
+       expect(screen.getByText("Need to understand credential formats before making changes")).toBeInTheDocument();
+   });
+   ```
+
+2. **Update** the existing "renders ticket cards" test to include the new ticket subject.
+
+3. **Update** the "Module 3 unlocks" test (if it asserts locked state based on Module 4 having no scenarios — Module 4 auto-satisfies, so this should still work, but verify).
+
+---
+
+## Verification
+
+1. **Lint:** `npx eslint src/data/scenarios.js src/__tests__/TicketInbox.test.jsx`
+2. **Tests:** `npx vitest run` — all tests pass
+3. **Build:** `npm run build` — no compilation errors
+4. **Dev console:** Zero `[Scenario "scenario_credential_building"]` validation warnings
+5. **Inbox check:** Module 3 shows 2 tickets (#1005, #1006) when Module 2 is completed

--- a/src/__tests__/TicketInbox.test.jsx
+++ b/src/__tests__/TicketInbox.test.jsx
@@ -38,8 +38,9 @@ describe("TicketInbox", () => {
         // Module 2 tickets
         expect(screen.getByText("How do I set up Google provisioning?")).toBeInTheDocument();
         expect(screen.getByText("Explain the provisioning steps before we change anything")).toBeInTheDocument();
-        // Module 3 ticket
+        // Module 3 tickets
         expect(screen.getByText("Change student email format to first initial + last name")).toBeInTheDocument();
+        expect(screen.getByText("Need to understand credential formats before making changes")).toBeInTheDocument();
     });
 
     it("downstream modules are locked when prerequisites are not completed", () => {
@@ -58,8 +59,9 @@ describe("TicketInbox", () => {
             ]),
             completedModules: new Set(["mod_overview", "mod_provisioning_basics"]),
         });
-        const ticket = screen.getByText("Change student email format to first initial + last name");
-        expect(ticket).toBeInTheDocument();
+        // Both Module 3 tickets should render unlocked
+        expect(screen.getByText("Change student email format to first initial + last name")).toBeInTheDocument();
+        expect(screen.getByText("Need to understand credential formats before making changes")).toBeInTheDocument();
         expect(screen.queryByText("Complete previous modules to unlock")).not.toBeInTheDocument();
     });
 

--- a/src/data/scenarios.js
+++ b/src/data/scenarios.js
@@ -812,16 +812,22 @@ export const scenarios = [
         ]
     },
 
-    // ── Scenario 3B: Credential Building Concepts ────────────────
+    // ═══════════════════════════════════════════════════════════════
+    //  MODULE 3B — Credential Configuration (Deeper Knowledge)
+    // ═══════════════════════════════════════════════════════════════
+
+    // ── Scenario 3B: Understanding Credential Formats ──────────────
     {
         id: "scenario_credential_building",
         title: "Understanding Credential Formats",
-        description: "Help Sarah Chen understand credential formats before making changes.",
+        description: "Help Sarah Chen understand how credential formats work across user types before configuring changes.",
+
         customerId: "sarahChen",
         moduleId: "mod_credentials",
         ticketSubject: "Need to understand credential formats before making changes",
         ticketPriority: "normal",
         ticketNumber: 1006,
+
         nextScenario: null,
         settings: {},
 
@@ -830,182 +836,182 @@ export const scenarios = [
             {
                 id: "step_cb_intro",
                 type: "message",
-                text: "Before I make changes, I want to understand the format system.",
+                text: "Hi! Before I make any changes to our credential setup, I want to make sure I fully understand how the format system works. I've seen the credential cards but I have a bunch of questions. Can you help me work through them?",
                 sender: "customer",
                 actions: [
-                    { label: "I can help explain that. What would you like to know?", nextStep: "step_cb_user_types" }
-                ]
+                    { label: "Of course! I'd be happy to walk through the credential system with you.", nextStep: "step_cb_user_types" },
+                ],
             },
-            // ── 2. User types ─────────────────────────────────────
+            // ── 2. How many user types have credentials? ──────────
             {
                 id: "step_cb_user_types",
                 type: "input",
-                text: "How many user types have credential configurations?",
+                text: "Great, let's start basic. How many user types have credential configurations in the provisioning wizard? I want to make sure I'm not missing any.",
                 sender: "customer",
-                guideMessage: "Consider the types of users configured for provisioning.",
+                guideMessage: "Count the user types (students, teachers, staff) that have credential cards configured in the wizard.",
                 correctAnswer: ["3", "three"],
                 matchMode: "oneOf",
                 successStep: "step_cb_shared_domain",
                 hint: {
-                    message: "Look at the user types configured for provisioning (Students, Teachers, Staff)."
+                    message: "Think about the different roles in a school district — students, teachers, and staff each have their own credential card.",
                 },
-                autoShowHint: false
+                autoShowHint: false,
             },
-            // ── 3. Shared domain ──────────────────────────────────
+            // ── 3. Shared domain question ─────────────────────────
             {
                 id: "step_cb_shared_domain",
                 type: "input",
-                text: "Do they share a domain? What is it?",
+                text: "Good — students, teachers, and staff. Do they all use the same email domain, or does each type have its own? What domain is it?",
                 sender: "customer",
-                guideMessage: "Identify the shared domain across user types.",
+                guideMessage: "Check the email format on any credential card — what comes after the @ sign?",
                 correctAnswer: "maytonlyceum.com",
                 matchMode: "includes",
                 successStep: "step_cb_sis_variables",
                 hint: {
-                    message: "Check the domain used in the email formats."
+                    message: "Look at the email format on the credential cards — the domain after the @ symbol is shared across all three user types.",
                 },
-                autoShowHint: false
+                autoShowHint: false,
             },
-            // ── 4. SIS variables ──────────────────────────────────
+            // ── 4. SIS variables differ by type ───────────────────
             {
                 id: "step_cb_sis_variables",
                 type: "message",
-                text: "Are SIS variables the same for all types?",
+                text: "Here's what I'm confused about — are the same SIS variables available for all user types when building email formats, or are they different?",
                 sender: "customer",
                 actions: [
-                    { label: "They're different per type", nextStep: "step_cb_student_variable" },
-                    { label: "Yes, they use the exact same variables", nextStep: "step_cb_sis_variables_wrong" }
-                ]
+                    { label: "They're different. Each user type has its own set of SIS variables, plus shared ones like First Name and Last Name.", nextStep: "step_cb_student_variable" },
+                    { label: "They're all the same — every user type uses the same variables.", nextStep: "step_cb_sis_variables_wrong" },
+                ],
             },
-            // ── 4a. SIS variables wrong ───────────────────────────
+            // ── 4a. Wrong SIS variables answer ────────────────────
             {
                 id: "step_cb_sis_variables_wrong",
                 type: "message",
-                text: "Students have Student Number but teachers don't…",
+                text: "That doesn't sound right. I thought students had a Student Number variable but teachers don't? Aren't the type-specific variables different?",
                 sender: "customer",
                 actions: [
-                    { label: "You're right, they're different per type.", nextStep: "step_cb_student_variable" }
-                ]
+                    { label: "You're right — each user type has unique variables. Students have Student Number, teachers have Teacher Number, and staff have Title and Department.", nextStep: "step_cb_student_variable" },
+                ],
             },
-            // ── 5. Student variable ───────────────────────────────
+            // ── 5. Student-specific variable count ────────────────
             {
                 id: "step_cb_student_variable",
                 type: "input",
-                text: "Besides First/Last Name, how many student email variables?",
+                text: "OK so students have their own variables. Besides First Name and Last Name, how many additional SIS variables are available specifically for student email formats?",
                 sender: "customer",
-                guideMessage: "Count the available student email variables barring first and last name.",
+                guideMessage: "Count the student-specific email SIS variables (excluding name.first and name.last). Check the EMAIL_SIS_VARIABLES reference.",
                 correctAnswer: "4",
                 matchMode: "exact",
                 successStep: "step_cb_password_format",
                 hint: {
-                    message: "Count the available variables like sis_id, student_number, state_id, district_username."
+                    message: "Student email variables include: First Name, Last Name, SIS ID, Student Number, State ID, and District Username. That's 6 total — minus 2 name fields = 4 unique student variables.",
                 },
-                autoShowHint: false
+                autoShowHint: false,
             },
-            // ── 6. Password format ────────────────────────────────
+            // ── 6. Student password format ────────────────────────
             {
                 id: "step_cb_password_format",
                 type: "message",
-                text: "What does the student password format combine?",
+                text: "Now I'm curious about passwords. The student password format looks like a bunch of variables strung together. What does the student password format actually combine?",
                 sender: "customer",
                 actions: [
-                    { label: "student number + grade + school SIS ID", nextStep: "step_cb_teacher_password" },
-                    { label: "first name + last name", nextStep: "step_cb_password_format_wrong" }
-                ]
+                    { label: "It combines the student number, grade, and school SIS ID — three variables concatenated together.", nextStep: "step_cb_teacher_password" },
+                    { label: "It uses the student's first name and birthday.", nextStep: "step_cb_password_format_wrong" },
+                ],
             },
-            // ── 6a. Password format wrong ─────────────────────────
+            // ── 6a. Wrong password format ─────────────────────────
             {
                 id: "step_cb_password_format_wrong",
                 type: "message",
-                text: "I saw student_number and grade variables…",
+                text: "Hmm, I don't think that's right. I saw variables like student_number and grade in the password field. Can you look at it again?",
                 sender: "customer",
                 actions: [
-                    { label: "Oh yes, it's student number + grade + school SIS ID.", nextStep: "step_cb_teacher_password" }
-                ]
+                    { label: "Sorry about that — the student password format is student number + grade + school SIS ID.", nextStep: "step_cb_teacher_password" },
+                ],
             },
-            // ── 7. Teacher password ───────────────────────────────
+            // ── 7. Teacher password computation ───────────────────
             {
                 id: "step_cb_teacher_password",
                 type: "input",
-                text: "Betty Bauch, teacher number T001 — what's her password?",
+                text: "Let me test my understanding with a real example. Our sample teacher is Betty Bauch with teacher number T001. The teacher password format uses the teacher number plus a fixed string '0420'. What would Betty's actual password be?",
                 sender: "customer",
-                guideMessage: "Determine the password for an existing teacher based on the format.",
+                guideMessage: "The teacher password template is {{teacher.teacher_number}}0420. Substitute Betty Bauch's teacher number (T001) to compute her password.",
                 correctAnswer: "t0010420",
                 matchMode: "exact",
                 successStep: "step_cb_fallback",
                 hint: {
-                    message: "Check the teacher password format and substitute T001 for teacher_number."
+                    message: "The teacher password format is {{teacher.teacher_number}}0420. Betty's teacher number is T001, so her password is T0010420.",
                 },
-                autoShowHint: false
+                autoShowHint: false,
             },
-            // ── 8. Fallback ───────────────────────────────────────
+            // ── 8. Fallback format concept ────────────────────────
             {
                 id: "step_cb_fallback",
                 type: "message",
-                text: "What's a fallback email format?",
+                text: "One more concept I've been wondering about — what's a fallback email format? I see there's an option to add one but none of our user types have it enabled right now.",
                 sender: "customer",
                 actions: [
-                    { label: "Used when primary produces a conflict", nextStep: "step_cb_matching" },
-                    { label: "An alternative password recovery email", nextStep: "step_cb_fallback_wrong" }
-                ]
+                    { label: "A fallback format is used when the primary email format produces a conflict — for example, if two users would get the same email address.", nextStep: "step_cb_matching" },
+                    { label: "A fallback format is the email used when users forget their password.", nextStep: "step_cb_fallback_wrong" },
+                ],
             },
-            // ── 8a. Fallback wrong ────────────────────────────────
+            // ── 8a. Wrong fallback answer ─────────────────────────
             {
                 id: "step_cb_fallback_wrong",
                 type: "message",
-                text: "Password reset is different. Fallback is about conflicts?",
+                text: "That doesn't sound right — password reset is a different thing entirely. I think fallback has to do with email conflicts when two users would get the same address?",
                 sender: "customer",
                 actions: [
-                    { label: "Yes, it's used when the primary email format produces a conflict.", nextStep: "step_cb_matching" }
-                ]
+                    { label: "Correct — the fallback format kicks in when the primary format would create a duplicate email address, so each user still gets a unique email.", nextStep: "step_cb_matching" },
+                ],
             },
-            // ── 9. Matching ───────────────────────────────────────
+            // ── 9. Email matching vs. creating ────────────────────
             {
                 id: "step_cb_matching",
                 type: "message",
-                text: "What's the difference between matching and creating?",
+                text: "Last conceptual question. I noticed the credential step mentions 'matching emails' and 'creating emails' as two different things. What's the difference between those?",
                 sender: "customer",
                 actions: [
-                    { label: "Matching links existing Google accts via SIS email; creating builds new ones", nextStep: "step_cb_staff_email" },
-                    { label: "They both create new Google accounts", nextStep: "step_cb_matching_wrong" }
-                ]
+                    { label: "Matching links existing Google accounts to Clever users by comparing their SIS email. Creating builds new email addresses for unmatched users using the format you configure.", nextStep: "step_cb_staff_email" },
+                    { label: "They're the same thing — both create new Google accounts.", nextStep: "step_cb_matching_wrong" },
+                ],
             },
-            // ── 9a. Matching wrong ────────────────────────────────
+            // ── 9a. Wrong matching answer ─────────────────────────
             {
                 id: "step_cb_matching_wrong",
                 type: "message",
-                text: "SIS email matching sounds different from creating new ones?",
+                text: "I don't think they're the same. The credential step says something about 'SIS email' matching with existing Google accounts. That sounds different from creating new ones, right?",
                 sender: "customer",
                 actions: [
-                    { label: "Right, matching links existing Google accts via SIS email; creating builds new ones.", nextStep: "step_cb_staff_email" }
-                ]
+                    { label: "Right — matching uses the SIS email to find existing Google accounts automatically, while creating builds new addresses for users who don't already have a Google account.", nextStep: "step_cb_staff_email" },
+                ],
             },
-            // ── 10. Staff email ───────────────────────────────────
+            // ── 10. Staff email computation ───────────────────────
             {
                 id: "step_cb_staff_email",
                 type: "input",
-                text: "Oswaldo Pouros — what would his email be?",
+                text: "OK final test! Our sample staff member is Oswaldo Pouros. Using the current email format, what would his email address be?",
                 sender: "customer",
-                guideMessage: "Determine the email for Oswaldo Pouros.",
+                guideMessage: "The email format is {{name.first}}{{name.last}}@maytonlyceum.com. Substitute Oswaldo Pouros's name to compute his email.",
                 correctAnswer: ["oswaldopouros@maytonlyceum.com", "oswaldo.pouros@maytonlyceum.com"],
                 matchMode: "oneOf",
                 successStep: "step_cb_done",
                 hint: {
-                    message: "Format uses first+last or first.last at maytonlyceum.com."
+                    message: "The format is first name + last name + @maytonlyceum.com. For Oswaldo Pouros: oswaldopouros@maytonlyceum.com",
                 },
-                autoShowHint: false
+                autoShowHint: false,
             },
             // ── 11. Done ──────────────────────────────────────────
             {
                 id: "step_cb_done",
                 type: "message",
-                text: "Three types, shared domain, different SIS variables… I'm confident now!",
+                text: "That all makes sense now! Three user types sharing the same domain, different SIS variables per type, password formats using SIS data, fallback for conflicts, and matching vs creating. I feel much more confident about making changes now. Thanks so much for walking me through all of this!",
                 sender: "customer",
                 actions: [
-                    { label: "Glad to help! Let us know if you have any other questions.", nextStep: null },
-                    { label: "You're all set! Have a great day.", nextStep: null }
-                ]
-            }
-        ]
-    }
+                    { label: "You've got it! Let us know when you're ready to make the actual format changes.", nextStep: null },
+                    { label: "Great understanding, Sarah! Don't hesitate to reach out if you need help editing the formats.", nextStep: null },
+                ],
+            },
+        ],
+    },
 ];


### PR DESCRIPTION
Implementation of scenario_credential_building for phase 8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new scenario data and adjusts unit test expectations; no production logic changes beyond rendering an additional existing module ticket.
> 
> **Overview**
> Completes Module 3 by adding a new conceptual training ticket, `scenario_credential_building`, which quizzes users on credential-format fundamentals (user types/domains, SIS variables, password templates, fallback behavior, and matching vs. creating) via an 11-step Q&A flow with wrong-answer correction branches.
> 
> Updates `TicketInbox` unit tests to expect two unlocked Module 3 tickets/subjects now that the second scenario is authored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ee15799011d002c0403d7ea602a0a9468edc9b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->