### PR TITLE
Phase 4 salvage: mode-aware scoring + branching + helpdesk UI

### DIFF
--- a/src/__tests__/InvestigationView.test.jsx
+++ b/src/__tests__/InvestigationView.test.jsx
@@ -189,7 +189,7 @@ describe("InvestigationView", () => {
                 scores: { correct: 3, total: 4, timeMs: 180000 },
             },
         });
-        expect(screen.getByText("Investigation Complete")).toBeInTheDocument();
+        expect(screen.getByText(/Excellent Work with Guidance!/)).toBeInTheDocument();
         expect(screen.getByText("3/4")).toBeInTheDocument();
         expect(screen.getByText("3m 00s")).toBeInTheDocument();
         expect(screen.getByText(/Replay/)).toBeInTheDocument();

--- a/src/__tests__/TicketInbox.test.jsx
+++ b/src/__tests__/TicketInbox.test.jsx
@@ -81,9 +81,13 @@ describe("TicketInbox", () => {
         renderInbox({
             completedScenarios: new Set(["scenario_idm_orientation"]),
             scores: {
-                scenario_idm_orientation: { correct: 3, total: 4, timeMs: 120000, startTime: 0 }
+                scenario_idm_orientation: {
+                    guided: { correct: 3, total: 4, timeMs: 120000, startTime: 0 },
+                    unguided: null,
+                },
             },
         });
+        expect(screen.getByText(/Guided:/)).toBeInTheDocument();
         expect(screen.getByText(/3\/4/)).toBeInTheDocument();
         expect(screen.getByText(/2m 00s/)).toBeInTheDocument();
     });

--- a/src/components/helpdesk/InvestigationView.jsx
+++ b/src/components/helpdesk/InvestigationView.jsx
@@ -247,8 +247,21 @@ export default function InvestigationView() {
                 {scenarioJustCompleted && (
                     <div className={styles.completionCard}>
                         <div className={styles.completionIcon}>\u2705</div>
-                        <div className={styles.completionTitle}>Investigation Complete</div>
+                        <div className={styles.completionTitle}>
+                            {coachMarksEnabled ? "Excellent Work with Guidance!" : "Strong Independent Performance!"}
+                        </div>
+                        <div className={styles.completionMessage}>
+                            {coachMarksEnabled 
+                                ? "With coach marks and guidance, you successfully navigated this investigation. Consider trying the unguided mode to test your independence."
+                                : "You successfully completed this investigation unaided - demonstrating strong independent problem-solving skills."}
+                        </div>
                         <div className={styles.completionStats}>
+                            <div className={styles.completionStat}>
+                                <span className={styles.statLabel}>Mode</span>
+                                <span className={styles.statValue}>
+                                    {coachMarksEnabled ? "📍 Guided" : "🧭 Unguided"}
+                                </span>
+                            </div>
                             <div className={styles.completionStat}>
                                 <span className={styles.statLabel}>Score</span>
                                 <span className={styles.statValue}>

--- a/src/components/helpdesk/InvestigationView.module.css
+++ b/src/components/helpdesk/InvestigationView.module.css
@@ -318,14 +318,25 @@
     font-size: 18px;
     font-weight: 700;
     color: var(--text-primary);
+    margin-bottom: 8px;
+}
+
+.completionMessage {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.4;
     margin-bottom: 16px;
+    max-width: 400px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .completionStats {
     display: flex;
     justify-content: center;
-    gap: 24px;
+    gap: 16px;
     margin-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .completionStat {

--- a/src/components/helpdesk/TicketInbox.jsx
+++ b/src/components/helpdesk/TicketInbox.jsx
@@ -271,8 +271,15 @@ export default function TicketInbox() {
                                                 <div className={styles.ticketMeta}>
                                                     {isDone && scenarioScore ? (
                                                         <span className={styles.ticketScore}>
-                                                            ✓ {scenarioScore.correct}/{scenarioScore.total}
-                                                            {scenarioScore.timeMs ? ` · ${formatTime(scenarioScore.timeMs)}` : ""}
+                                                            ✓ <span className={styles.scoreModeLabel}>Guided:</span> {scenarioScore.guided?.correct || 0}/{scenarioScore.guided?.total || 0}
+                                                            {scenarioScore.guided?.timeMs ? ` · ${formatTime(scenarioScore.guided.timeMs)}` : ""}
+                                                            {scenarioScore.unguided && (
+                                                                <>
+                                                                    <br />
+                                                                    <span className={styles.scoreModeLabel}>Unguided:</span> {scenarioScore.unguided.correct}/{scenarioScore.unguided.total}
+                                                                    {scenarioScore.unguided.timeMs ? ` · ${formatTime(scenarioScore.unguided.timeMs)}` : ""}
+                                                                </>
+                                                            )}
                                                         </span>
                                                     ) : locked ? (
                                                         <span className={styles.ticketLockedLabel}>

--- a/src/components/helpdesk/TicketInbox.module.css
+++ b/src/components/helpdesk/TicketInbox.module.css
@@ -308,6 +308,11 @@
     font-weight: 600;
 }
 
+.scoreModeLabel {
+    font-weight: 600;
+    color: var(--gray-600);
+}
+
 .ticketLockedLabel {
     color: var(--gray-500);
     font-style: italic;

--- a/src/data/scenarios.js
+++ b/src/data/scenarios.js
@@ -55,8 +55,8 @@ export const scenarios = [
                 question: "What identity provider is configured on this IDM page?",
                 choices: [
                     { label: "Google Workspace", nextStep: "step_orient_health", correct: true },
-                    { label: "Microsoft Entra ID", nextStep: "step_orient_provider_wrong", correct: false },
-                    { label: "Both Google and Microsoft", nextStep: "step_orient_provider_wrong", correct: false },
+                    { label: "Microsoft Entra ID", nextStep: "step_orient_provider_wrong", unguidedNextStep: "step_orient_health", correct: false },
+                    { label: "Both Google and Microsoft", nextStep: "step_orient_provider_wrong", unguidedNextStep: "step_orient_health", correct: false },
                 ],
                 hint: {
                     target: "google-provider-card",
@@ -112,7 +112,7 @@ export const scenarios = [
                 question: "Looking at the sync history, are syncs running regularly or has there been a gap?",
                 choices: [
                     { label: "Syncs are running regularly — the most recent one was within the last few days", nextStep: "step_orient_nav_tasks", correct: true },
-                    { label: "Syncs have stopped — the last one was weeks ago", nextStep: "step_orient_sync_wrong", correct: false },
+                    { label: "Syncs have stopped — the last one was weeks ago", nextStep: "step_orient_sync_wrong", unguidedNextStep: "step_orient_nav_tasks", correct: false },
                 ],
                 hint: {
                     message: "Check the dates in the Sync History table — are they recent and consistent?",
@@ -223,8 +223,8 @@ export const scenarios = [
                 question: "Looking at the Sync History tab, what's the overall health of the sync process?",
                 choices: [
                     { label: "All syncs completed successfully, though each has a minor issue flagged", nextStep: "step_tabs_click_exports", correct: true },
-                    { label: "Multiple syncs have failed — there are serious problems", nextStep: "step_tabs_sync_wrong", correct: false },
-                    { label: "There's no sync history — syncing hasn't been set up", nextStep: "step_tabs_sync_wrong", correct: false },
+                    { label: "Multiple syncs have failed — there are serious problems", nextStep: "step_tabs_sync_wrong", unguidedNextStep: "step_tabs_click_exports", correct: false },
+                    { label: "There's no sync history — syncing hasn't been set up", nextStep: "step_tabs_sync_wrong", unguidedNextStep: "step_tabs_click_exports", correct: false },
                 ],
                 hint: {
                     message: "Look at the Status column in the Sync History table — are they showing success or failure?",
@@ -263,7 +263,7 @@ export const scenarios = [
                 question: "What export capabilities does the Exports tab offer?",
                 choices: [
                     { label: "Manual CSV downloads plus an SFTP option for automated exports", nextStep: "step_tabs_click_events", correct: true },
-                    { label: "Only manual downloads — there's no automation option", nextStep: "step_tabs_exports_wrong", correct: false },
+                    { label: "Only manual downloads — there's no automation option", nextStep: "step_tabs_exports_wrong", unguidedNextStep: "step_tabs_click_events", correct: false },
                 ],
                 hint: {
                     target: "exports-tab-content",
@@ -303,7 +303,7 @@ export const scenarios = [
                 question: "What kind of information does the Events tab show?",
                 choices: [
                     { label: "Individual user-level changes — account creations, updates, and which user types were affected", nextStep: "step_tabs_nav_tasks", correct: true },
-                    { label: "Only system-level errors and warnings, not individual user changes", nextStep: "step_tabs_events_wrong", correct: false },
+                    { label: "Only system-level errors and warnings, not individual user changes", nextStep: "step_tabs_events_wrong", unguidedNextStep: "step_tabs_nav_tasks", correct: false },
                 ],
                 hint: {
                     target: "events-tab-content",
@@ -405,7 +405,7 @@ export const scenarios = [
                 question: "The first wizard step is 'Connect to Google.' Is Google already connected for this district?",
                 choices: [
                     { label: "Yes — the Connect step shows Google is already connected and authorized", nextStep: "step_wn_nav_mgmt", correct: true },
-                    { label: "No — Google still needs to be set up", nextStep: "step_wn_connection_wrong", correct: false },
+                    { label: "No — Google still needs to be set up", nextStep: "step_wn_connection_wrong", unguidedNextStep: "step_wn_nav_mgmt", correct: false },
                 ],
                 hint: {
                     target: "wizard-step-connect",


### PR DESCRIPTION
## Summary
Salvages valid Phase 4 work from the mixed subagent output into a clean branch.

### Included
- `InstructionalContext` state version bump + v1->v2 migration helpers
- Central unguided branching target resolver (`unguidedNextStep`)
- Mode-aware score handling (`guided` / `unguided`)
- Helpdesk UI score rendering for guided/unguided
- Completion card mode messaging
- Updated tests to match mode-aware UI/score shape

### Excluded intentionally
- `.gitignore` noise
- `Build_Instructions_Portal.md`
- unrelated docs files

## Validation
- `npm test` ✅ (189/189)
- `npm run lint` ✅
- `npm run build` ✅
