### PR TITLE
Navigate directly to user profiles from Data Browser & add step undo

### DIFF
--- a/src/components/helpdesk/ChatView.module.css
+++ b/src/components/helpdesk/ChatView.module.css
@@ -170,6 +170,7 @@
     padding: 16px;
     display: flex;
     flex-direction: column;
+    justify-content: flex-end;
     gap: 12px;
 }
 
@@ -590,6 +591,21 @@
 
 .skipButton:hover {
     color: var(--error);
+}
+
+.backStepButton {
+    background: none;
+    border: none;
+    color: var(--clever-blue);
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 2px 4px;
+    transition: opacity 0.15s;
+}
+
+.backStepButton:hover {
+    opacity: 0.7;
 }
 
 /* ═══ Animations ═══ */


### PR DESCRIPTION
## Summary
- **Data Browser:** Clicking a student, teacher, or staff row now navigates directly to their profile page (`router.push`) instead of opening the right-side detail overlay. Name columns render as plain text matching real Clever. Detail panel retained for Schools/Sections only.
- **Helpdesk chat:** Added go-back/undo functionality with a step history stack and chat message snapshots for clean rewind. Added typing indicator on module intro and improved staggered ticket entrance timing.

## Test plan
- [ ] Navigate to Data Browser → Students tab → click a row → verify it navigates to the student profile page
- [ ] Repeat for Teachers and Staff tabs
- [ ] Verify Schools and Sections tabs still open the detail overlay
- [ ] Verify student/teacher/staff names in the Data Browser are plain text (not blue links)
- [ ] In helpdesk chat, advance through steps and verify the ← Back button appears and rewinds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)